### PR TITLE
Allow passing of additional plugins besides Flask

### DIFF
--- a/flask_continuum/plugin.py
+++ b/flask_continuum/plugin.py
@@ -82,8 +82,10 @@ class Continuum(object):
         db (SQLAlchemy): SQLAlchemy extension to associate with plugin.
         user_cls (str): Name of user class used in application.
         engine (Engine): SQLAlchemy engine to associate with plugin.
-        current_user (callable): Callable object to determine user assocaited
+        current_user (callable): Callable object to determine user associated
                                  with request.
+        plugins (List): List of other SQLAlchemy-Continuum plugins to install.
+            see: https://sqlalchemy-continuum.readthedocs.io/en/latest/plugins.html
 
     """
 

--- a/flask_continuum/plugin.py
+++ b/flask_continuum/plugin.py
@@ -87,7 +87,7 @@ class Continuum(object):
 
     """
 
-    def __init__(self, app=None, db=None, user_cls=None, engine=None, current_user=fetch_current_user_id):
+    def __init__(self, app=None, db=None, user_cls=None, engine=None, current_user=fetch_current_user_id, plugins=[]):
         self.db = None
         self.app = None
         self.engine = engine
@@ -114,7 +114,7 @@ class Continuum(object):
             user_cls=self.user_cls,
             plugins=[
                 FlaskPlugin(current_user_id_factory=self.current_user)
-            ]
+            ] + plugins
         )
         return
 


### PR DESCRIPTION
Currently Flask-Continuum will only install Flask plugin, however, it may be useful to pass in extra plugins, such as `PropertyModTrackerPlugin`.

This change simply adds an extra arg to `Continuum` constructor to allow extra plugin instances to be passed in.